### PR TITLE
remove double entry for link /districts/:district

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -199,11 +199,6 @@ app.get('/districts', queuedCache(), cache.route(), async (req, res) => {
   res.json(response)
 })
 
-app.get('/districts/:district', queuedCache(), cache.route(), async (req, res) => {
-  const response = await DistrictsResponse(req.params.district);
-  res.json(response)
-})
-
 app.get('/districts/history', async (req, res) => {
   res.redirect('/districts/history/cases')
 })


### PR DESCRIPTION
Remove double entry block for app.get('/districts/:district'
1st from line 202 - 205
2nd from line 251 - 254